### PR TITLE
Add support for env and fatalError options

### DIFF
--- a/examples/script.js
+++ b/examples/script.js
@@ -1,8 +1,27 @@
-import exec from 'k6/x/exec';
+import exec from "k6/x/exec";
 
 export default function () {
   console.log(exec.command("date"));
-  console.log(exec.command("ls",["-a","-l"], {
-    "dir": "sub-directory" // optional directory in which the command has to be run
-  }));
+
+  // Changes the directory before running the command
+  console.log(
+    exec.command("ls", ["-a", "-l"], {
+      dir: "sub-directory", // optional directory in which the command has to be run
+    }),
+  );
+
+  // Sets an environment variable
+  console.log(
+    exec.command("bash", ["-c", "echo $FOO"], {
+      env: ["FOO=bar"],
+    }),
+  );
+
+  // Allows to change behavior when command fails.
+  // This will make the stderr be returned instead of the stdout
+  console.log(
+    exec.command("false", [], {
+      fatalError: false,
+    }),
+  );
 }


### PR DESCRIPTION
env allows to specify environment variables that will be passed to the command being executed.

fatalError allows to change the default behaviour that will abort the test execution, allowing for expected failures to not break k6.

When the command exits with a non zero error code, the stderr will be returned instead of the stdout