### PR TITLE
Return error instead of killing process

### DIFF
--- a/examples/script.js
+++ b/examples/script.js
@@ -1,8 +1,25 @@
 import exec from 'k6/x/exec';
 
 export default function () {
+  // Basic example:
   console.log(exec.command("date"));
+  
+  // With custom error handling:
+  try {
+    var output = exec.command("ls",["-a", "NO_SUCH_DIR"], {
+      "continue_on_error": true
+    });
+  } catch (e) {
+        console.log("ERROR: " + e);
+        if (e.value && e.value.stderr) {
+                console.log("STDERR: " + String.fromCharCode.apply(null, e.value.stderr))
+        }
+  }
+
+  // without error handling the test will stop when the following command fails
   console.log(exec.command("ls",["-a","-l"], {
     "dir": "sub-directory" // optional directory in which the command has to be run
   }));
+
+  console.log("this message will not be printed")
 }

--- a/exec.go
+++ b/exec.go
@@ -24,7 +24,8 @@ type EXEC struct {
 
 // CommandOptions contains the options that can be passed to command.
 type CommandOptions struct {
-	Dir string
+	Dir             string
+	ContinueOnError bool
 }
 
 // Ensure the interfaces are implemented correctly.
@@ -46,14 +47,16 @@ func (exec *EXEC) Exports() modules.Exports {
 }
 
 // Command is a wrapper for Go exec.Command
-func (*EXEC) Command(name string, args []string, option CommandOptions) string {
+func (*EXEC) Command(name string, args []string, option CommandOptions) (string, error) {
 	cmd := exec.Command(name, args...)
 	if option.Dir != "" {
 		cmd.Dir = option.Dir
 	}
+
 	out, err := cmd.Output()
-	if err != nil {
+	if err != nil && !option.ContinueOnError {
 		log.Fatal(err.Error() + " on command: " + name + " " + strings.Join(args, " "))
 	}
-	return string(out)
+
+	return string(out), err
 }


### PR DESCRIPTION
Rather than kill the whole load test (which is what `log.Fatal` does), proposing to delegate error handling so user can decide on:
- retry policy
- tracking error/retry metrics
- finer-grained error handling policy
