### PR TITLE
fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,7 @@ issues:
       text: "does not use range value in test Run"
     - linters:
         - forbidigo
-      text: 'use of `os\.(SyscallError|Signal|Interrupt)` forbidden'
+      text: 'use of `os\.(SyscallError|Signal|Interrupt|ProcessState)` forbidden'
 
 linters-settings:
   nolintlint:

--- a/exec.go
+++ b/exec.go
@@ -31,13 +31,13 @@ type CommandOptions struct {
 	IncludeStdoutOnError bool
 }
 
-type MyExitError struct {
+type myExitError struct {
 	ProcessState *os.ProcessState
 	Stderr       []byte
 	Stdout       []byte
 }
 
-func (e *MyExitError) Error() string {
+func (e *myExitError) Error() string {
 	return e.ProcessState.String()
 }
 
@@ -73,12 +73,12 @@ func (*EXEC) Command(name string, args []string, option CommandOptions) (string,
 
 	if err != nil && option.IncludeStdoutOnError {
 		var exitErr *exec.ExitError
-		var myExitError MyExitError
+		var myExitErr myExitError
 		if errors.As(err, &exitErr) {
-			myExitError.Stderr = exitErr.Stderr
-			myExitError.Stdout = out
-			myExitError.ProcessState = exitErr.ProcessState
-			return string(out), &myExitError
+			myExitErr.Stderr = exitErr.Stderr
+			myExitErr.Stdout = out
+			myExitErr.ProcessState = exitErr.ProcessState
+			return string(out), &myExitErr
 		}
 	}
 


### PR DESCRIPTION
Fix lint errors

```
run golangci-lint
  Running [/home/runner/golangci-lint-1.52.2-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  Error: use of `os.ProcessState` forbidden because "Using anything except Signal and SyscallError from the os package is forbidden" (forbidigo)
  Error: exported: exported type MyExitError should have comment or be unexported (revive)
  
  Error: issues found
  Ran golangci-lint in 726ms
```